### PR TITLE
Fall back to hosted dev environment when .env is not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ yarn
 
 ### Run
 ```
-yarn serve-remote
+yarn serve
 ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "serve-remote": "env VUE_APP_API_BASEURL=https://primer-git-dev.blacksocialists.now.sh/api vue-cli-service serve",
     "build": "vue-cli-service build"
   },
   "dependencies": {

--- a/src/env.js
+++ b/src/env.js
@@ -1,7 +1,11 @@
 export const api = {
-  baseUrl: process.env.VUE_APP_API_BASEURL,
+  baseUrl:
+    process.env.VUE_APP_API_BASEURL
+    || 'https://primer-git-dev.blacksocialists.now.sh/api',
   endpoints: {
-    config: process.env.VUE_APP_API_ENDPOINT_CONFIG
+    config:
+      process.env.VUE_APP_API_ENDPOINT_CONFIG
+      || '/config',
   }
 }
 


### PR DESCRIPTION
idk why i didnt do this before

`serve-remote` is no longer required